### PR TITLE
Stop the BOOST_ROOT environment variable from influencing the find_package result

### DIFF
--- a/Release/cmake/cpprest_find_boost.cmake
+++ b/Release/cmake/cpprest_find_boost.cmake
@@ -3,6 +3,9 @@ function(cpprest_find_boost)
     return()
   endif()
 
+  # Stop the BOOST_ROOT environment variable from influencing the find_package result
+  set(ENV{BOOST_ROOT} "")
+
   if(IOS)
     set(IOS_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../Build_iOS")
     set(Boost_LIBRARIES "${IOS_SOURCE_DIR}/boost.framework/boost" CACHE INTERNAL "")


### PR DESCRIPTION
Updating the submodule for this PR:
https://github.com/Mojang/Minecraftpe/pull/13185